### PR TITLE
Add (optional) expiration to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ Usage of slacker:
   -clear
     	Clears your away and custom status
   -config string
-    	Which config file to use (default "~/.slack")
+    	Which config file to use (default "/Users/inkel/.slack")
   -d	Enable debug mode
   -emoji string
     	Set status emoji
+  -expires-at string
+    	Set an absolute expiration
+  -expires-in duration
+    	Set a relative expiration (e.g. 1h15m30s)
+  -online
+    	Set yourself online
   -text string
     	Set status text
 ```


### PR DESCRIPTION
Add `-expires-in` and `-expires-at` mutually exclusive flags to add [expiration to custom statuses](https://api.slack.com/docs/presence-and-status#expiration).

* `-expires-in` takes a [`time.Duration`](https://golang.org/pkg/time/#Duration) to set a relative time expiration (e.g. `2m`)
* `-expires-at` takes a `string` with a `YYYY-MM-DDThh:mm:ss` format to set an absolute time for expiration.

## ToDo

* [x] pass `status_expiration`
* [x] update README